### PR TITLE
Remove RFC from Early HInts

### DIFF
--- a/src/data.ts
+++ b/src/data.ts
@@ -74,7 +74,7 @@ const data: Idata = {
     },
     {
       code: 103,
-      shortDescription: "Early Hints (RFC 8297)",
+      shortDescription: "Early Hints",
       description:
         "Used to return some response headers before final HTTP message."
     },


### PR DESCRIPTION
Siema Paweł!

Early Hints (103) is no longer in RFC! It's in the HTML Spec now 😊

https://html.spec.whatwg.org/#early-hints

https://twitter.com/htmlstandard/status/1514627482569355269
