### PR TITLE
Added project description in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "httpsc",
   "version": "0.0.6",
+  "description": "Simple HTTP status codes reference CLI",
   "license": "MIT",
   "author": "Pawel Grzybek <grzybecki@gmail.com> (https://pawelgrzybek.com/)",
   "main": "./dist/index.js",


### PR DESCRIPTION
I was going through some of the npm tools that I use and noticed that this one didn't have a description. So I forked the repo and added the project description to it.